### PR TITLE
Use tag key 'curator.something-' instead of 'something-'

### DIFF
--- a/lambda/main.py
+++ b/lambda/main.py
@@ -100,7 +100,9 @@ def lambda_handler(event, context):
             if 'curator.default' in tag['Key']:
                 curator_default = tag['Value']
                 continue
-            curator_config[prefix] = retention_period
+            if prefix.startswith('curator.'):
+                pref = prefix.replace('curator.', '')
+                curator_config[pref] = retention_period
 
         if curator_default != '':
             for index in es.indices.get('*'):


### PR DESCRIPTION
This will help have all Curator's tags close to each other in alphabetical list. Along with curator.default.
It's huge improvement in visibility when one have a lot of tags on resources.